### PR TITLE
Fix out of bounds bug in plotDMRs2

### DIFF
--- a/R/plotFunctions.R
+++ b/R/plotFunctions.R
@@ -195,6 +195,7 @@ plotDMRs2 <- function (BSseq, regions = NULL, testCovariate = NULL, extend = (en
                 temp <- c(temp[1] - 1, temp, temp[length(temp)] + 1) # Add adjacent CpGs
                 overlapExtend <- c(overlapExtend, temp)
         }
+        overlapExtend <- overlapExtend[overlapExtend > 0 & overlapExtend <= length(BSseq)]
         BSseq <- BSseq[overlapExtend,]
         
         if (!is.null(annoTrack) && !is.null(compareTrack)){


### PR DESCRIPTION
This fixes the out of bounds error when a DMR is near the first or last CpGs in the BSseq object