### PR TITLE
Add an optional caching feature

### DIFF
--- a/R/DM.R
+++ b/R/DM.R
@@ -87,8 +87,8 @@ DM.R <- function(genome = c("hg38", "hg19", "mm10", "mm9", "rheMac10",
   stopifnot(coverage >= 1)
   
   if(tryCache){
-    print(glue::glue("Warning: You have specified tryCache == TRUE. This is useful when \\
-                   resuming jobs that were interrupted, but any command line run paramaters will be \\
+    print(glue::glue("Warning: You have specified tryCache = TRUE. This can be useful when \\
+                   resuming an interrupted job, but changes to command line parameters will be \\
                    ignored -- and will instead be loaded from the cached RData/settings.RData file."))
   }
   
@@ -133,15 +133,15 @@ DM.R <- function(genome = c("hg38", "hg19", "mm10", "mm9", "rheMac10",
   # Setup annotation databases ----------------------------------------------
   
   cat("\n[DMRichR] Selecting annotation databases \t\t", format(Sys.time(), "%d-%m-%Y %X"), "\n")
+
+  DMRichR::annotationDatabases(genome = genome,
+                               EnsDb = EnsDb)
   
   cachefile_settings = "RData/settings.RData"
   if (file.exists(cachefile_settings) { 
     print(glue::glue("\tLoading cached file: {cachefile_settings}"))
     load(cachefile_settings)
   } else {
-    DMRichR::annotationDatabases(genome = genome,
-                                 EnsDb = EnsDb)
-
     print(glue::glue("Saving Rdata..."))
     dir.create("RData")
     settings_env <- ls(all = TRUE)

--- a/exec/DM.R
+++ b/exec/DM.R
@@ -59,6 +59,8 @@ option_list <- list(
                         help = "Logical to select Ensembl transcript annotation database [default = %default]"),
   optparse::make_option(c("-f", "--GOfuncR"), type = "logical", default = TRUE,
                         help = "Logical to run GOfuncR GO analysis [default = %default]")
+  optparse::make_option("--tryCache", type = "logical", default = FALSE,
+                        help = "Try to load cached data from an interrupted run via RData/ [default = %default]")
 )
 opt <- optparse::parse_args(optparse::OptionParser(option_list = option_list))
 
@@ -85,5 +87,6 @@ DMRichR::DM.R(genome = opt$genome,
               GOfuncR = opt$GOfuncR,
               sexCheck = opt$sexCheck,
               EnsDb = opt$EnsDb,
-              cellComposition = opt$cellComposition)
+              cellComposition = opt$cellComposition,
+              tryCache = opt$tryCache)
     

--- a/exec/DM.R
+++ b/exec/DM.R
@@ -58,7 +58,7 @@ option_list <- list(
   optparse::make_option(c("-d", "--EnsDb"), type = "logical", default = FALSE,
                         help = "Logical to select Ensembl transcript annotation database [default = %default]"),
   optparse::make_option(c("-f", "--GOfuncR"), type = "logical", default = TRUE,
-                        help = "Logical to run GOfuncR GO analysis [default = %default]")
+                        help = "Logical to run GOfuncR GO analysis [default = %default]"),
   optparse::make_option("--tryCache", type = "logical", default = FALSE,
                         help = "Try to load cached data from an interrupted run via RData/ [default = %default]")
 )

--- a/exec/DM.R.sh
+++ b/exec/DM.R.sh
@@ -51,7 +51,8 @@ call="Rscript \
 --sexCheck TRUE \
 --GOfuncR TRUE \
 --EnsDb FALSE \
---cores 20"
+--cores 20 \
+--tryCache FALSE"
 
 echo $call
 eval $call


### PR DESCRIPTION
When jobs crash or are interrupted, some components (e.g. processing blocks with dmrseq) are tedious to re-process.

In my particular cluster, it can be hard to get an interactive session and resume or selectively process parts of jobs.

This adds an optional caching flag `--tryCache` to attempt to load cached .RData files if they're available.
